### PR TITLE
change subent to ip

### DIFF
--- a/JumpscaleLib/clients/zero_boot/ZerobootClient.py
+++ b/JumpscaleLib/clients/zero_boot/ZerobootClient.py
@@ -207,20 +207,22 @@ class Networks:
         """
         return list(self._networks.keys())
 
-    def get(self, subnet=None):
-        """get network object from its subnet
+    def get(self, ip=None):
+        """get network object from the host ip
 
-        :param subnet: subnet required, defaults to None in that case will get first in the list
-        :type subnet: str
-        :raises KeyError: if subnet doesn't exist in available subnets
+        :param ip: ip required, defaults to None in that case will get first in the list
+        :type ip: str
+        :raises KeyError: if ip doesn't exist in available subnets
         :return: network object
         :rtype: object
         """
-        if not subnet:
-            subnet = self.list()[0]
-        if subnet not in self._networks:
-            raise KeyError("Network with specified subnet: %s doesn't exist" % subnet)
-        return self._networks[subnet]
+        if not ip:
+            ip = self.list()[0].split('/')[0]
+        for subnet in self._networks:
+            if netaddr.IPAddress(ip) in netaddr.IPNetwork(subnet):
+                return self._networks[subnet]
+        else:
+            raise KeyError("Host with specified IP: %s doesn't exist" % ip)
 
     def remove(self, subnet):
         raise NotImplementedError()


### PR DESCRIPTION
#### What this PR resolves:
Using the old code we had to pass `data['network']=<router_ip/subnet>` to get the client. I removed that part and make sure that the host ip is in the same local nw with the router

