### PR TITLE
add coredns client

### DIFF
--- a/JumpscaleLib/sal/coredns/CoreDnsClient.py
+++ b/JumpscaleLib/sal/coredns/CoreDnsClient.py
@@ -1,0 +1,72 @@
+from Jumpscale import j
+import json
+from .encoding import (encode_record,unregister_record,load)
+from .ResourceRecord import ResourceRecord ,RecordType
+JSConfigBase = j.tools.configmanager.JSBaseClassConfig
+
+TEMPLATE = """
+etcd_instance = "main"
+"""
+class CoreDnsClient(JSConfigBase):
+
+    def __init__(self, instance, data={}, parent=None, interactive=False):
+        JSConfigBase.__init__(self, instance=instance,
+                              data=data, parent=parent, template=TEMPLATE, interactive=interactive)
+        self._etcd_client = None
+        print ("CoreDNS", instance)
+        self._zones = []
+
+
+    @property
+    def etcd_client(self):
+        if not self._etcd_client:
+            self._etcd_client = j.clients.etcd.get(self.config.data['etcd_instance'])
+        return self._etcd_client
+
+    @property
+    def zones(self):
+        """get all zones 
+        """
+        if not self._zones:
+            self._zones = load(self.etcd_client)
+        return self._zones
+
+    def zone_create(self, domain, rrdata, record_type=RecordType.A,  ttl=300, priority=None, port=None ):
+        """ create new zone .
+
+            domain    : Record Name.  Corresponds to first field in
+                      DNS Bind Zone file entries.  REQUIRED.
+            rrdata  : Resource Record Data (REQUIRED)
+            record_type    : Record Type.  CNAME, A, AAAA, TXT, SRV.  REQUIRED
+            ttl     : time to live. default value 300 (optional)
+            priority: SRV record priority (optional)
+            port    : SRV record port (optional)
+
+            TXT record example  : rrdata = 'this is a TXT record'
+            A record example    : rrdata = '1.1.1.1'
+            AAAA record example : rrdata = '2003:8:1'
+            SRV record example  : rrdata = 'skydns-local.server'
+            CNAME record example: rrdata = 'cn1.skydns.local skydns.local.'
+        """
+        zone = ResourceRecord(domain, rrdata, record_type, ttl, priority, port)
+        self._zones.append(zone)
+        return zone
+
+    def deploy(self):
+        """
+        add coredns records in etcd
+        :param zones: list of `ResourceRecord` objects that needs to be added
+        """
+        for zone in self.zones:
+            key, value = encode_record(zone)
+            self.etcd_client.put(key, value)
+    
+    def remove(self, zones):
+        """
+        remove coredns records from etcd
+        :param zones: list of `ResourceRecord` objects that needs to be removed
+        """
+        for zone in zones:
+            key = unregister_record(zone)
+            self.etcd_client.api.delete_prefix(key)
+

--- a/JumpscaleLib/sal/coredns/CoreDnsFactory.py
+++ b/JumpscaleLib/sal/coredns/CoreDnsFactory.py
@@ -1,0 +1,31 @@
+from Jumpscale import j
+
+from .CoreDnsClient import CoreDnsClient
+
+JSConfigFactory = j.tools.configmanager.JSBaseClassConfigs
+
+
+class CoreDnsFactory(JSConfigFactory):
+    def __init__(self):
+        self.__jslocation__ = "j.sal.coredns"
+        JSConfigFactory.__init__(self, CoreDnsClient)
+
+    def configure(self, instance_name, host, port="2379", user="root", password="root"):
+        """
+        gets an instance of coredns client with etcd configurations directly
+        """
+        j.clients.etcd.get(instance_name, data={"host": host, "port": port, "user": user, "password_": password})
+        return self.get(instance_name, data={"etcd_instance": instance_name})
+
+    def test(self):
+        #create etcd client
+        cl = j.sal.coredns.configure(instance_name="main",host="10.144.72.95",password="njufdmrq3k")
+        #create zones
+        zone1 = cl.zone_create('test.example.com','10.144.13.199',record_type='A')
+        zone2 = cl.zone_create('example.com','2003::8:1',record_type='AAAA')
+        #add records in etcd
+        cl.deploy() 
+        #get records from etcd
+        cl.zones
+        #remove records from etcd
+        cl.remove([zone1,zone2])

--- a/JumpscaleLib/sal/coredns/ResourceRecord.py
+++ b/JumpscaleLib/sal/coredns/ResourceRecord.py
@@ -1,0 +1,75 @@
+import json
+from enum import Enum
+
+class RecordType(Enum):
+    A = "A"
+    AAAA = "AAAA"
+    SRV = "SRV"
+    TXT = "TXT"
+
+class ResourceRecord:
+
+    def __init__(self, domain, rrdata, record_type=RecordType.A, ttl=300,
+                             priority=None, port=None # SRV
+                ):
+        """ DNS Resource Record.
+
+            domain    : Record Name.  Corresponds to first field in
+                      DNS Bind Zone file entries.  REQUIRED.
+            record_type    : Record Type.  CNAME, A, AAAA, TXT, SRV.  REQUIRED
+            ttl     : time to live. default value 300 (optional)
+            port    : SRV record port (optional)
+            priority: SRV record priority (optional)
+            rrdata  : Resource Record Data (REQUIRED)
+
+            TXT record example  : rrdata = 'this is a TXT record'
+            A record example    : rrdata = '1.1.1.1'
+            AAAA record example : rrdata = '2003:8:1'
+            SRV record example  : rrdata = 'skydns-local.server'
+            CNAME record example: rrdata = 'cn1.skydns.local skydns.local.'
+        """
+
+        if rrdata is None:
+            rrdata = ''
+
+        self.type = record_type
+        if self.type == 'CNAME':
+            self.cname, rrdata = rrdata.split(' ')
+        self.domain = domain
+        self.port = port
+        self.priority = priority
+        self.ttl = ttl
+        self.weight = 100
+        self._rrdata = rrdata
+
+
+    @property
+    def rrdata(self):
+        """ reconstructs CoreDNS/etcd-style JSON data format
+        """
+        res = {'ttl': self.ttl}
+        rdatafield = 'host' # covers SRV, A, AAAA and CNAME
+        if self.type == RecordType.TXT:
+            rdatafield = 'text'
+        elif self.type == RecordType.SRV:
+            res['priority'] = self.priority
+            res['port'] = self.port
+        elif self.type == 'CNAME':
+            res['cname'] = self._rrdata 
+            res['host'] = self.cname  
+        res[rdatafield] = self._rrdata
+        return json.dumps(res)
+
+    def __str__(self):
+        if self.type == 'TXT':
+            rrdata = '"%s"' % self._rrdata
+        else:
+            rrdata = self._rrdata
+        extra = 'IN\t%s' % self.type
+        if self.type == 'SRV':
+            extra += '\t%d %d %d' % (self.priority, self.weight, self.port)
+        return "%s\t%d\t%s\t%s" % \
+            (self.domain, self.ttl, extra, rrdata)
+
+    def __repr__(self):
+            return "'%s'" % str(self)

--- a/JumpscaleLib/sal/coredns/encoding.py
+++ b/JumpscaleLib/sal/coredns/encoding.py
@@ -1,0 +1,76 @@
+from urllib.parse import urlparse
+from ipaddress import IPv4Address, IPv6Address
+from ipaddress import AddressValueError, NetmaskValueError
+import json
+from .ResourceRecord import ResourceRecord
+
+def encode_record(zone):
+    """encode zone record 
+    
+    Arguments:
+        zone : ResourceRecord object that needs to be encoded
+    """
+    domain_parts = zone.domain.split('.')
+    # The key for coredns should start with path(/hosts) and the domain reversed
+    # i.e. test.com => /hosts/com/test
+    key = "/hosts/{}".format("/".join(domain_parts[::-1]))
+    return key,zone.rrdata
+
+def unregister_record(zone):
+    """return encoded key of zone record that needs to be deleted 
+    Arguments:
+        zone : ResourceRecord object that needs to be encoded
+    """
+    domain_parts = zone.domain.split('.')
+    # The key for coredns should start with path(/hosts) and the domain reversed
+    # i.e. test.com => /hosts/com/test
+    key = "/hosts/{}".format("/".join(domain_parts[::-1]))
+    return key
+
+def load(client):
+    """get all zones from etcd
+    
+    Arguments:
+        client : ETCD client
+    """
+    zones = []
+    for value, metadata in client.api.get_prefix('/hosts'):
+        ss = metadata.key.decode().split('/')
+        domain = '.'.join(reversed(ss[2:]))
+        value = json.loads(value.decode())
+        type_of_record , rrdata = get_type_and_rdata(value)
+        if type_of_record == "SRV":
+            zone = ResourceRecord(domain,rrdata,type_of_record,value["ttl"],value["priority"],value["port"])
+        else:
+            zone = ResourceRecord(domain,rrdata,type_of_record,value["ttl"])
+        zones.append(zone)
+    return zones
+
+def get_type_and_rdata(record):
+    """get type and data of record
+    
+    Arguments:
+        record: dict value of zone
+
+    Returns: type and data of type
+    """
+    if "text" in record:
+        return 'TXT', record['text']
+    elif "port" in record:
+        return 'SRV', record['host']
+    elif "cname" in record:
+        return 'CNAME', record['cname']
+    elif "host" in record:
+        rrdata = record['host']
+        try:
+            IPv6Address(rrdata)
+            rtype = 'AAAA'
+            return rtype, rrdata
+        except (AddressValueError, NetmaskValueError):
+            try:
+                IPv4Address(rrdata)
+                rtype = 'A'
+                return rtype, rrdata
+            except (AddressValueError, NetmaskValueError):
+                pass
+    raise KeyError("cannot identify record type %s" % repr(record))

--- a/JumpscaleLib/sal/coredns/test_coredns.py
+++ b/JumpscaleLib/sal/coredns/test_coredns.py
@@ -1,0 +1,105 @@
+from .encoding import load,encode_record,unregister_record,get_type_and_rdata
+from .CoreDnsClient import CoreDnsClient
+from .ResourceRecord import ResourceRecord
+
+class Meta:
+
+    def __init__(self, key):
+        self.key = key
+
+
+class Api:
+    def __init__(self, client):
+        self._client = client
+
+    def get(self, key):
+        if isinstance(key, str):
+            key = key.encode()
+        value = self._client._data.get(key)
+        return (value, Meta(key))
+
+    def get_prefix(self, prefix):
+        if isinstance(prefix, str):
+            prefix = prefix.encode()
+        for k, v in list(self._client._data.items()):
+            if k.startswith(prefix):
+                yield (v, Meta(k))
+
+    def delete_prefix(self, prefix):
+        if isinstance(prefix, str):
+            prefix = prefix.encode()
+        for k in list(self._client._data.keys()):
+            if k.startswith(prefix):
+                del self._client._data[k]
+
+
+class EtcdClientMock:
+    def __init__(self):
+        self._data = {}
+        self.api = Api(self)
+
+    def put(self, key, value):
+        if isinstance(value, str):
+            value = value.encode()
+        self._data[key.encode()] = value
+
+    def get(self, key):
+        return self._data.get(key)
+
+
+def test_zone_deploy_remove():
+    client = EtcdClientMock()
+    zone1 = ResourceRecord('test1.example.com','10.144.13.199',record_type='A')
+    key, value = encode_record(zone1)
+    client.put(key, value)
+    zone2 = ResourceRecord('test2.example.com','2003::8:1',record_type='AAAA')
+    key, value = encode_record(zone2)
+    client.put(key, value)
+
+    assert client._data == {
+        b'/hosts/com/example/test1': b'{"ttl": 300, "host": "10.144.13.199"}',
+        b'/hosts/com/example/test2': b'{"ttl": 300, "host": "2003::8:1"}',
+    }
+
+    key = unregister_record(zone1)
+    client.api.delete_prefix(key)
+    key = unregister_record(zone2)
+    client.api.delete_prefix(key)
+    assert client._data == {}
+
+def test_encoding_zone():
+    client = EtcdClientMock()
+    zone1 = ResourceRecord('test1.example.com','10.144.13.199',record_type='A')
+    key, value = encode_record(zone1)
+    client.put(key, value)
+    zone2 = ResourceRecord('test2.example.com','2003::8:1',record_type='AAAA')
+    key, value = encode_record(zone2)
+    client.put(key, value)
+
+    assert client._data == {
+        b'/hosts/com/example/test1': b'{"ttl": 300, "host": "10.144.13.199"}',
+        b'/hosts/com/example/test2': b'{"ttl": 300, "host": "2003::8:1"}',
+    }
+
+def test_backend_load():
+    client = EtcdClientMock()
+    client._data = {
+        b'/hosts/com/example/test1': b'{"ttl": 300, "host": "10.144.13.199"}',
+        b'/hosts/com/example/test2': b'{"ttl": 300, "host": "2003::8:1"}',
+    }
+    zones = load(client)
+    print(zones[0].rrdata)
+    assert zones[0].domain == "test1.example.com"
+    assert zones[0].rrdata == '{"ttl": 300, "host": "10.144.13.199"}'
+    assert zones[0].ttl == 300
+    assert zones[1].domain == 'test2.example.com'
+    assert zones[1].rrdata == '{"ttl": 300, "host": "2003::8:1"}'
+    assert zones[1].ttl == 300
+
+def test_type_and_rdata():
+    type_of_record, metadata = get_type_and_rdata({"ttl": 300, "host": "10.144.13.199"})
+    assert type_of_record == "A"
+    assert metadata == "10.144.13.199"
+    type_of_record, metadata = get_type_and_rdata({"ttl": 300, "host": "2003::8:1"})
+    assert type_of_record == "AAAA"
+    assert metadata == "2003::8:1"


### PR DESCRIPTION
can use coredns client :
```python
        #create etcd client
        cl = j.sal.coredns.configure(instance_name="main",host="10.144.72.95",password="njufdmrq3k")
        #create zones
        zone1 = cl.zone_create('test.example.com','10.144.13.199',record_type='A')
        zone2 = cl.zone_create('example.com','2003::8:1',record_type='AAAA')
        #add records in etcd
        cl.deploy() 
        #get records from etcd
        cl.zones
        #remove records from etcd
        cl.remove([zone1,zone2])
```