### PR TITLE
added call for raw disk.isstandby

### DIFF
--- a/JumpscaleLib/clients/zero_os_protocol/DiskManager.py
+++ b/JumpscaleLib/clients/zero_os_protocol/DiskManager.py
@@ -50,6 +50,10 @@ class DiskManager:
         'disk': str,
     })
 
+    _isstandby_chk = typchk.Checker({
+        'disk': str,
+    })
+
     def __init__(self, client):
         self._client = client
 
@@ -305,6 +309,21 @@ class DiskManager:
         result = response.get()
         if result.state != 'SUCCESS':
             raise RuntimeError("Failed to spindown disk {} to {}.".format(disk, spindown))
+
+    def isstandby(self, disk):
+        """
+        Verify if a disk is powered down (i.e. it's still available, but went
+        in standby mode, and stopped spinning after spindown (see above) interval)
+        NOTE: default of spindown is 1, so after 5 seconds, and not accessed the disk
+        will stop spinning
+        :param disk str: Full path to a disk like /dev/sda
+        """
+        args = {
+            "disk": disk,
+        }
+        self._isstandby_chk.check(args)
+
+        return self._client.json("disk.isstandby",args)
 
     def seektime(self, disk):
         """


### PR DESCRIPTION
#### What this PR resolves:
basically we want to have a way to verify if a disk is in standby mode before we use some **real** disk access for monitoring purposes.

if a disk is `disk.spindown` with Core-0 we have to verify that the disk is effectively spun down and keep it that way if we run monitor checks on these diks/mountpoints.

That also means that all monitor templates that create/delet files for the sole purpose of verifying availability of a disk should **first** verify if it's in standby mode. If that is the case, skip the check, whatever that is.

goes together with `https://github.com/threefoldtech/0-core/commit/a00c4df490e3364c0c2770ca0bdc5cb1b029fa46`
