### PR TITLE
Add isstandby disk

### DIFF
--- a/JumpscaleLib/clients/zero_os_protocol/Client.py
+++ b/JumpscaleLib/clients/zero_os_protocol/Client.py
@@ -24,6 +24,7 @@ from .WebManager import WebManager
 from .ZerotierManager import ZerotierManager
 from .ZFSManager import ZFSManager
 from .SocatManager import SocatManager
+from .PowerManager import PowerManager
 
 
 TEMPLATE = """
@@ -75,6 +76,11 @@ class Client(BaseClient, JSConfigClientBase):
         self._cgroup = CGroupManager(self)
         self._zfs = ZFSManager(self)
         self._socat = SocatManager(self)
+        self._power = PowerManager(self)
+
+    @property
+    def power(self):
+        return self._power
 
     @property
     def socat(self):

--- a/JumpscaleLib/clients/zero_os_protocol/DiskManager.py
+++ b/JumpscaleLib/clients/zero_os_protocol/DiskManager.py
@@ -50,6 +50,10 @@ class DiskManager:
         'disk': str,
     })
 
+    _isstandby_chk = typchk.Checker({
+        'disk': str,
+    })
+
     def __init__(self, client):
         self._client = client
 
@@ -305,6 +309,21 @@ class DiskManager:
         result = response.get()
         if result.state != 'SUCCESS':
             raise RuntimeError("Failed to spindown disk {} to {}.".format(disk, spindown))
+
+    def isstandby(self, disk):
+        """
+        Verify if a disk is powered down (i.e. it's still available, but went
+        in standby mode, and stopped spinning after spindown (see above) interval)
+        NOTE: default of spindown is 1, so after 5 seconds, and not accessed the disk
+        will stop spinning
+        :param disk str: Full path to a disk like /dev/sda
+        """
+        args = {
+            "disk": disk,
+        }
+        self._isstandby_chk.check(args)
+
+        return self._client.json("disk.isstandby",args)
 
     def seektime(self, disk):
         """

--- a/JumpscaleLib/clients/zero_os_protocol/PowerManager.py
+++ b/JumpscaleLib/clients/zero_os_protocol/PowerManager.py
@@ -1,0 +1,38 @@
+from . import typchk
+
+
+class PowerManager:
+    _image_chk = typchk.Checker({
+        'image': str,
+    })
+
+    def __init__(self, client):
+        self._client = client
+
+    def reboot(self):
+        """
+        full reboot of the node
+        """
+        self._client.raw('core.reboot', {}, stream=True).stream()
+
+    def poweroff(self):
+        """
+        full power off of the node
+        """
+        self._client.raw('core.poweroff', {}, stream=True).stream()
+
+    def update(self, image):
+        """
+        update the node with given image, and fast reboot into this image
+        No hardware reboot will ahppend
+
+        :param image: efi image name, the image will be downloaded from https://bootstrap.grid.tf/kernel
+                      example: "zero-os-development.efi"
+        """
+
+        args = {
+            'image': image
+        }
+
+        self._image_chk.check(args)
+        self._client.raw('core.update', args, stream=True).stream()

--- a/JumpscaleLib/sal_zos/abstracts.py
+++ b/JumpscaleLib/sal_zos/abstracts.py
@@ -139,7 +139,7 @@ class ZTNic(Nic):
 
     @property
     def client(self):
-        logger.info("******* zt client name {}".format(self._client_name))
+        logger.info("******* zt client name {} exists {}".format(self._client_name, j.clients.zerotier.exists(self._client_name)))
         if self._client is None and j.clients.zerotier.exists(self._client_name):
             self._client = j.clients.zerotier.get(self._client_name, create=False, die=True, interactive=False)
         logger.info("****** zt client {}".format(self._client))

--- a/JumpscaleLib/sal_zos/primitives/Primitives.py
+++ b/JumpscaleLib/sal_zos/primitives/Primitives.py
@@ -3,7 +3,7 @@ from ..vm.ZOS_VM import ZOS_VM, IpxeVM, ZDBDisk
 
 
 BASEFLIST = 'https://hub.grid.tf/tf-bootable/{}.flist'
-ZEROOSFLIST = 'https://hub.grid.tf/tf-autobuilder/zero-os-development.flist'
+ZEROOSFLIST = 'https://hub.grid.tf/tf-autobuilder/{}.flist'
 
 
 class Primitives:
@@ -24,7 +24,9 @@ class Primitives:
         templatename, _, version = type_.partition(':')
         kwargs = {'name': name, 'node': self.node}
         if templatename == 'zero-os':
-            kwargs['flist'] = ZEROOSFLIST
+            version = version or 'development'
+            flistname = '{}-{}'.format(templatename, version)
+            kwargs['flist'] = ZEROOSFLIST.format(flistname)
         elif templatename == 'ubuntu':
             version = version or 'lts'
             flistname = '{}:{}'.format(templatename, version)


### PR DESCRIPTION
What this PR resolves:

basically we want to have a way to verify if a disk is in standby mode before we use some real disk access for monitoring purposes.

if a disk is disk.spindown with Core-0 we have to verify that the disk is effectively spun down and keep it that way if we run monitor checks on these diks/mountpoints.

That also means that all monitor templates that create/delet files for the sole purpose of verifying availability of a disk should first verify if it's in standby mode. If that is the case, skip the check, whatever that is.

That goes together with https://github.com/threefoldtech/0-core/pull/101